### PR TITLE
#2  Update home directory references in scripts and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.tmp
 /build
 /.idea
+/.evmstation

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -16,7 +16,7 @@ KEYRING="test"
 KEYALGO="eth_secp256k1"
 LOGLEVEL="info"
 # Set dedicated home directory for the ./build/bin/evmstationd instance
-HOMEDIR="./.tmp/polard"
+HOMEDIR="./.evmstation"
 # to trace evm
 #TRACE="--trace"
 TRACE=""
@@ -29,7 +29,7 @@ TMP_GENESIS=$HOMEDIR/config/tmp_genesis.json
 
 
 # Check if ../.tmp directory exists
-if [ -d "../.tmp" ]; then
+if [ -d "./.evmstation" ]; then
     read -p "The evm station directory already exists. Do you want to continue? (y/n) " -n 1 -r
     echo    # Move to a new line
     if [[ $REPLY =~ ^[Nn]$ ]]
@@ -41,7 +41,7 @@ if [ -d "../.tmp" ]; then
 fi
 
 
-rm -rf ./.tmp
+rm -rf ./.evmstation
 rm -rf ./build
 make clean
 make build
@@ -78,7 +78,7 @@ set -e
 
 # Change the Default EVM Config
 
-sed -i "/\[polaris\.polar\.chain\]/!b;n;c chain-id = \"$EVMCHAINID\"" ../.tmp/polard/config/app.toml
+sed -i "/\[polaris\.polar\.chain\]/!b;n;c chain-id = \"$EVMCHAINID\"" ./.evmstation/config/app.toml
 ## Change exactly  persistent peers in config.toml
 
 

--- a/scripts/local-start.sh
+++ b/scripts/local-start.sh
@@ -2,6 +2,6 @@
 
 #Normal With CometBFT
 #./build/bin/evmstationd start --pruning=nothing "" --log_level info --api.enabled-unsafe-cors --api.enable --api.swagger --minimum-gas-prices=0.0001abera --home "./.tmp/evmstationd"
-
+HOMEDIR="./.evmstation"
 #First Implementation of  StationBFT
-../build/bin/evmstationd-v1  start --pruning=nothing "" --log_level info --api.enabled-unsafe-cors --api.enable --api.swagger --minimum-gas-prices=0.0001abera --home "../.tmp/polard"
+./build/bin/evmstationd  start --pruning=nothing "" --log_level info --api.enabled-unsafe-cors --api.enable --api.swagger --minimum-gas-prices=0.0001abera --home "$HOMEDIR"


### PR DESCRIPTION
The home directory referenced in number of script files has been changed from '.tmp' to '.evmstation'. As part of the update process, the old home directory reference '.tmp' has been replaced everywhere it appears with '.evmstation'. In addition, '.evmstation' has been added to .gitignore to prevent unnecessary tracking of this directory.